### PR TITLE
Add NVTX instrumentation for CUDA kernels and memops

### DIFF
--- a/main.cu
+++ b/main.cu
@@ -85,13 +85,35 @@ int main() {
                 uint8_t tagCPU[16], tagGPU[16];
 
                 uint8_t *d_plain=nullptr,*d_cipher=nullptr,*d_tag=nullptr;
+                // NVTX Start: Malloc
+                NVTX_PUSH("Malloc");
                 CHECK_CUDA(cudaMalloc(&d_plain, dataBytes));
+                NVTX_POP();
+                // NVTX End: Malloc
+                // NVTX Start: Malloc
+                NVTX_PUSH("Malloc");
                 CHECK_CUDA(cudaMalloc(&d_cipher, dataBytes));
-                if (mode=="gcm") CHECK_CUDA(cudaMalloc(&d_tag,16));
+                NVTX_POP();
+                // NVTX End: Malloc
+                if (mode=="gcm") {
+                    // NVTX Start: Malloc
+                    NVTX_PUSH("Malloc");
+                    CHECK_CUDA(cudaMalloc(&d_tag,16));
+                    NVTX_POP();
+                    // NVTX End: Malloc
+                }
                 printInputData(h_plain.data(), std::min<size_t>(64, h_plain.size()), "Host Input Data");
+                // NVTX Start: Memcpy Host→Device
+                NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                 CHECK_CUDA(cudaMemcpy(d_plain, h_plain.data(), dataBytes, cudaMemcpyHostToDevice));
+                NVTX_POP();
+                // NVTX End: Memcpy Host→Device
                 std::vector<uint8_t> deviceInput(h_plain.size());
+                // NVTX Start: Memcpy Device→Host
+                NVTX_PUSH("Memcpy Device\xE2\x86\x92Host");
                 CHECK_CUDA(cudaMemcpy(deviceInput.data(), d_plain, dataBytes, cudaMemcpyDeviceToHost));
+                NVTX_POP();
+                // NVTX End: Memcpy Device→Host
                 printInputData(deviceInput.data(), std::min<size_t>(64, deviceInput.size()), "Device Input Data");
 
                 dim3 block(256);
@@ -99,25 +121,87 @@ int main() {
                 cudaEvent_t start,stop; cudaEventCreate(&start); cudaEventCreate(&stop);
                 cudaEventRecord(start);
                 if (mode=="ecb" && keyBits==128) {
+                    // NVTX Start: ECB-128 Encrypt
+                    NVTX_PUSH("ECB-128 Encrypt");
                     aes128_ecb_encrypt<<<grid,block>>>(d_plain,d_cipher,nBlocks);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: ECB-128 Encrypt
                 } else if (mode=="ecb" && keyBits==256) {
+                    // NVTX Start: ECB-256 Encrypt
+                    NVTX_PUSH("ECB-256 Encrypt");
                     aes256_ecb_encrypt<<<grid,block>>>(d_plain,d_cipher,nBlocks);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: ECB-256 Encrypt
                 } else if (mode=="ctr" && keyBits==128) {
                     uint64_t ctrLo=0, ctrHi=0; packCtr(iv.data(),ctrLo,ctrHi);
+                    // NVTX Start: CTR-128 Encrypt
+                    NVTX_PUSH("CTR-128 Encrypt");
                     aes128_ctr_encrypt<<<grid,block>>>(d_plain,d_cipher,nBlocks,ctrLo,ctrHi);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: CTR-128 Encrypt
                 } else if (mode=="ctr" && keyBits==256) {
                     uint64_t ctrLo=0, ctrHi=0; packCtr(iv.data(),ctrLo,ctrHi);
+                    // NVTX Start: CTR-256 Encrypt
+                    NVTX_PUSH("CTR-256 Encrypt");
                     aes256_ctr_encrypt<<<grid,block>>>(d_plain,d_cipher,nBlocks,ctrLo,ctrHi);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: CTR-256 Encrypt
                 } else if (mode=="gcm" && keyBits==128) {
-                    uint8_t *d_iv=nullptr; CHECK_CUDA(cudaMalloc(&d_iv,12));
+                    uint8_t *d_iv=nullptr; 
+                    // NVTX Start: Malloc
+                    NVTX_PUSH("Malloc");
+                    CHECK_CUDA(cudaMalloc(&d_iv,12));
+                    NVTX_POP();
+                    // NVTX End: Malloc
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_iv, iv.data(),12,cudaMemcpyHostToDevice));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
+                    // NVTX Start: GCM-128 Encrypt
+                    NVTX_PUSH("GCM-128 Encrypt");
                     aes128_gcm_encrypt<<<1,256>>>(d_plain,d_cipher,nBlocks,d_iv,d_tag);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: GCM-128 Encrypt
+                    // NVTX Start: Free
+                    NVTX_PUSH("Free");
                     CHECK_CUDA(cudaFree(d_iv));
+                    NVTX_POP();
+                    // NVTX End: Free
                 } else if (mode=="gcm" && keyBits==256) {
-                    uint8_t *d_iv=nullptr; CHECK_CUDA(cudaMalloc(&d_iv,12));
+                    uint8_t *d_iv=nullptr; 
+                    // NVTX Start: Malloc
+                    NVTX_PUSH("Malloc");
+                    CHECK_CUDA(cudaMalloc(&d_iv,12));
+                    NVTX_POP();
+                    // NVTX End: Malloc
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_iv, iv.data(),12,cudaMemcpyHostToDevice));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
+                    // NVTX Start: GCM-256 Encrypt
+                    NVTX_PUSH("GCM-256 Encrypt");
                     aes256_gcm_encrypt<<<1,256>>>(d_plain,d_cipher,nBlocks,d_iv,d_tag);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: GCM-256 Encrypt
+                    // NVTX Start: Free
+                    NVTX_PUSH("Free");
                     CHECK_CUDA(cudaFree(d_iv));
+                    NVTX_POP();
+                    // NVTX End: Free
                 }
                 cudaEventRecord(stop);
                 CHECK_CUDA(cudaGetLastError());
@@ -128,38 +212,138 @@ int main() {
                           << (double)dataBytes/(1<<20) << " MiB in " << ms
                           << " ms -> " << thr << " GiB/s" << std::endl;
 
+                // NVTX Start: Memcpy Device→Host
+                NVTX_PUSH("Memcpy Device\xE2\x86\x92Host");
                 CHECK_CUDA(cudaMemcpy(h_cipher.data(), d_cipher, dataBytes, cudaMemcpyDeviceToHost));
-                if (mode=="gcm") CHECK_CUDA(cudaMemcpy(tagGPU, d_tag, 16, cudaMemcpyDeviceToHost));
+                NVTX_POP();
+                // NVTX End: Memcpy Device→Host
+                if (mode=="gcm") {
+                    // NVTX Start: Memcpy Device→Host
+                    NVTX_PUSH("Memcpy Device\xE2\x86\x92Host");
+                    CHECK_CUDA(cudaMemcpy(tagGPU, d_tag, 16, cudaMemcpyDeviceToHost));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Device→Host
+                }
 
                 if (mode=="ecb" && keyBits==128) {
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
+                    // NVTX Start: ECB-128 Decrypt
+                    NVTX_PUSH("ECB-128 Decrypt");
                     aes128_ecb_decrypt<<<grid,block>>>(d_cipher,d_plain,nBlocks);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: ECB-128 Decrypt
                 } else if (mode=="ecb" && keyBits==256) {
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
+                    // NVTX Start: ECB-256 Decrypt
+                    NVTX_PUSH("ECB-256 Decrypt");
                     aes256_ecb_decrypt<<<grid,block>>>(d_cipher,d_plain,nBlocks);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: ECB-256 Decrypt
                 } else if (mode=="ctr" && keyBits==128) {
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
                     uint64_t ctrLo=0, ctrHi=0; packCtr(iv.data(),ctrLo,ctrHi);
+                    // NVTX Start: CTR-128 Decrypt
+                    NVTX_PUSH("CTR-128 Decrypt");
                     aes128_ctr_decrypt<<<grid,block>>>(d_cipher,d_plain,nBlocks,ctrLo,ctrHi);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: CTR-128 Decrypt
                 } else if (mode=="ctr" && keyBits==256) {
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
                     uint64_t ctrLo=0, ctrHi=0; packCtr(iv.data(),ctrLo,ctrHi);
+                    // NVTX Start: CTR-256 Decrypt
+                    NVTX_PUSH("CTR-256 Decrypt");
                     aes256_ctr_decrypt<<<grid,block>>>(d_cipher,d_plain,nBlocks,ctrLo,ctrHi);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: CTR-256 Decrypt
                 } else if (mode=="gcm" && keyBits==128) {
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
-                    uint8_t *d_iv2=nullptr; CHECK_CUDA(cudaMalloc(&d_iv2,12));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
+                    uint8_t *d_iv2=nullptr; 
+                    // NVTX Start: Malloc
+                    NVTX_PUSH("Malloc");
+                    CHECK_CUDA(cudaMalloc(&d_iv2,12));
+                    NVTX_POP();
+                    // NVTX End: Malloc
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_iv2, iv.data(),12,cudaMemcpyHostToDevice));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
+                    // NVTX Start: GCM-128 Decrypt
+                    NVTX_PUSH("GCM-128 Decrypt");
                     aes128_gcm_decrypt<<<1,256>>>(d_cipher,d_plain,nBlocks,d_iv2,d_tag,d_tag);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: GCM-128 Decrypt
+                    // NVTX Start: Free
+                    NVTX_PUSH("Free");
                     CHECK_CUDA(cudaFree(d_iv2));
+                    NVTX_POP();
+                    // NVTX End: Free
                 } else if (mode=="gcm" && keyBits==256) {
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
-                    uint8_t *d_iv2=nullptr; CHECK_CUDA(cudaMalloc(&d_iv2,12));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
+                    uint8_t *d_iv2=nullptr; 
+                    // NVTX Start: Malloc
+                    NVTX_PUSH("Malloc");
+                    CHECK_CUDA(cudaMalloc(&d_iv2,12));
+                    NVTX_POP();
+                    // NVTX End: Malloc
+                    // NVTX Start: Memcpy Host→Device
+                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
                     CHECK_CUDA(cudaMemcpy(d_iv2, iv.data(),12,cudaMemcpyHostToDevice));
+                    NVTX_POP();
+                    // NVTX End: Memcpy Host→Device
+                    // NVTX Start: GCM-256 Decrypt
+                    NVTX_PUSH("GCM-256 Decrypt");
                     aes256_gcm_decrypt<<<1,256>>>(d_cipher,d_plain,nBlocks,d_iv2,d_tag,d_tag);
+                    CHECK_CUDA(cudaGetLastError());
+                    CHECK_CUDA(cudaDeviceSynchronize());
+                    NVTX_POP();
+                    // NVTX End: GCM-256 Decrypt
+                    // NVTX Start: Free
+                    NVTX_PUSH("Free");
                     CHECK_CUDA(cudaFree(d_iv2));
+                    NVTX_POP();
+                    // NVTX End: Free
                 }
                 CHECK_CUDA(cudaDeviceSynchronize());
+                // NVTX Start: Memcpy Device→Host
+                NVTX_PUSH("Memcpy Device\xE2\x86\x92Host");
                 CHECK_CUDA(cudaMemcpy(h_recovered.data(), d_plain, dataBytes, cudaMemcpyDeviceToHost));
+                NVTX_POP();
+                // NVTX End: Memcpy Device→Host
                 bool match = (h_recovered == h_plain);
                 std::cout << "    Round-trip " << mode << "-" << keyBits << " "
                           << (double)dataBytes/(1<<20) << " MiB "
@@ -209,7 +393,11 @@ int main() {
                 }
 #endif
                 if(d_tag) cudaMemset(d_tag,0,16);
+                // NVTX Start: Free
+                NVTX_PUSH("Free");
                 cudaFree(d_plain); cudaFree(d_cipher); if(d_tag) cudaFree(d_tag);
+                NVTX_POP();
+                // NVTX End: Free
             }
         }
     }


### PR DESCRIPTION
## Summary
- instrument CUDA AES driver with NVTX markers around kernel launches
- add NVTX ranges for cudaMalloc/cudaFree and cudaMemcpy operations
- check CUDA errors and synchronize after each kernel

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_684db9cb8f7083249bafb66ea2a35c83