### PR TITLE
Fix redundant constant declarations

### DIFF
--- a/aes128_ecb.cu
+++ b/aes128_ecb.cu
@@ -6,9 +6,7 @@
 #include <stdint.h>
 #include "aes_common.h"
 
-extern __constant__ uint32_t d_roundKeys[];     // 44 words
-extern __constant__ uint8_t  d_sbox[];
-extern __constant__ uint8_t  d_inv_sbox[];
+// Device constant memory declarations come from aes_common.h
 
 union Block {            // convenient byte/word view of a block
     uint32_t w[4];

--- a/aes256_ecb.cu
+++ b/aes256_ecb.cu
@@ -6,9 +6,7 @@
 #include <stdint.h>
 #include "aes_common.h"
 
-extern __constant__ uint32_t d_roundKeys[];     // 60 words
-extern __constant__ uint8_t  d_sbox[];
-extern __constant__ uint8_t  d_inv_sbox[];
+// Device constant memory declarations come from aes_common.h
 
 union Block {
     uint32_t w[4];


### PR DESCRIPTION
## Summary
- remove local `extern` declarations from ECB implementations
- rely on shared declarations in `aes_common.h`

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_684dbea814c08324a005e5e9829fa3d4