### PR TITLE
Rewrite main with benchmarking features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(CudaProject LANGUAGES CXX CUDA)
 # Require CUDA and set standards
 find_package(CUDAToolkit REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CUDA_STANDARD 14)
+set(CMAKE_CUDA_STANDARD 17) # Changed from 14 to 17
 
 # Target your GPU arch (8.6 for RTX 3050 Ti)
 set(CMAKE_CUDA_ARCHITECTURES 86)
@@ -62,3 +62,17 @@ target_compile_options(CudaProject PRIVATE
 set_property(TARGET CudaProject PROPERTY CUDA_ARCHITECTURES 86)
 set_source_files_properties(${CUDA_SOURCES} PROPERTIES
         CUDA_MAXIMUM_REGISTER_COUNT 64)  # ya da 128
+
+
+# In your CMakeLists.txt
+include_directories("C:/Users/efebasol/CLionProjects/aes_openSSL/openssl-3.3.3/include")
+
+target_link_libraries(CudaProject PRIVATE
+        "C:/Users/efebasol/CLionProjects/aes_openSSL/openssl-3.3.3/libssl.lib"
+        "C:/Users/efebasol/CLionProjects/aes_openSSL/openssl-3.3.3/libcrypto.lib"
+        crypt32.lib       # for Cert* functions
+        ws2_32.lib        # for socket-related functions
+        user32.lib
+        gdi32.lib
+        advapi32.lib
+        kernel32.lib)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# CUDA-AES Benchmark
+
+This project contains CUDA implementations of AES encryption kernels.
+
+## Build
+
+Ensure the NVIDIA CUDA Toolkit is installed and `nvcc` is in your `PATH`.
+Then build in Release mode using CMake:
+
+```bash
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j$(nproc)
+```
+
+The resulting executable `CudaProject` will be generated in the `build` directory.
+
+## Run
+
+Enable persistent GPU mode (optional):
+
+```bash
+sudo nvidia-smi -pm 1
+```
+
+Run the benchmark:
+
+```bash
+./CudaProject
+```
+
+The program executes AES in ECB, CTR and GCM modes for both 128 and 256-bit
+keys. It measures throughput for message sizes of 1 MB, 10 MB, 100 MB and 1 GB.
+Each configuration is executed 5 times. Example output line:
+
+```
+[RUN 3/5] [GPU] ctr-128 processed 100 MiB in 12.3 ms -> 7.9 GiB/s
+```
+
+Use these lines to compute averages for your experiments.
+

--- a/main.cu
+++ b/main.cu
@@ -7,9 +7,9 @@
 #include <filesystem>
 #include <chrono>
 #include <cstring>
-#include <getopt.h>
 #include <immintrin.h>
 #include <openssl/evp.h>
+#include <iostream>
 #include "aes_common.h"
 #include "profiling_helpers.h"
 
@@ -147,7 +147,13 @@ static int ctr_preview() {
 // GF multiply benchmark
 // -------------------------------
 static int gf_mult_bench() {
-    std::filesystem::create_directories("bench");
+    // Ensure directory exists, handle potential errors if std::filesystem is problematic
+    try {
+        std::filesystem::create_directories("bench");
+    } catch (const std::filesystem::filesystem_error& e) {
+        fprintf(stderr, "Filesystem error: %s\n", e.what());
+        // Decide if this is a fatal error or if the program can continue
+    }
     // CPU part
     double ms_cpu=0.0; {
         __m128i a = _mm_set_epi64x(0x0123456789abcdefULL,0xfedcba9876543210ULL);
@@ -164,7 +170,7 @@ static int gf_mult_bench() {
     double gbps_cpu = (1000000.0*128/1e9) / (ms_cpu/1000.0);
 
     // GPU part
-    double ms_gpu=0.0; double gbps_gpu=0.0; {
+    float ms_gpu=0.0; double gbps_gpu=0.0; {
         uint64_t *d_out; CHECK_CUDA(cudaMalloc(&d_out, THREADS_PER_BLOCK*sizeof(uint64_t)));
         cudaEvent_t s,e; cudaEventCreate(&s); cudaEventCreate(&e);
         cudaEventRecord(s);
@@ -186,7 +192,12 @@ static int gf_mult_bench() {
 // GCM debug routine: encrypt 64B and dump partial GHASH
 // -------------------------------
 static int gcm_debug_run() {
-    std::filesystem::create_directories("bench");
+    // Ensure directory exists
+    try {
+        std::filesystem::create_directories("bench");
+    } catch (const std::filesystem::filesystem_error& e) {
+        fprintf(stderr, "Filesystem error: %s\n", e.what());
+    }
     std::mt19937_64 rng(123);
     const size_t bytes=64; size_t nBlocks=bytes/16;
     uint8_t *h_plain,*h_cipher; CHECK_CUDA(cudaMallocHost(&h_plain,bytes)); CHECK_CUDA(cudaMallocHost(&h_cipher,bytes));
@@ -236,37 +247,68 @@ int main(int argc, char** argv) {
     int blockOverride = THREADS_PER_BLOCK;
     bool decrypt=false, doCtrPreview=false, doGcmDebug=false, doGfMult=false;
 
+    // getopt_long related code will be commented out for Windows compatibility
+    /*
     enum { OPT_CTR_PREVIEW=1000, OPT_GCM_DEBUG, OPT_GF_MULT };
     static struct option opts[] = {
-        {"block", required_argument, nullptr, 'b'},
-        {"decrypt", no_argument, nullptr, 'd'},
-        {"ctr-preview", no_argument, nullptr, OPT_CTR_PREVIEW},
-        {"gcm-debug", no_argument, nullptr, OPT_GCM_DEBUG},
-        {"gf-mult", no_argument, nullptr, OPT_GF_MULT},
-        {"help", no_argument, nullptr, 'h'},
+        {\"block\", required_argument, nullptr, \'b\'},
+        {\"decrypt\", no_argument, nullptr, \'d\'},
+        {\"ctr-preview\", no_argument, nullptr, OPT_CTR_PREVIEW},
+        {\"gcm-debug\", no_argument, nullptr, OPT_GCM_DEBUG},
+        {\"gf-mult\", no_argument, nullptr, OPT_GF_MULT},
+        {\"help\", no_argument, nullptr, \'h\'},
         {0,0,0,0}
     };
     while(true){
-        int idx=0; int c=getopt_long(argc,argv,"b:dh",opts,&idx); if(c==-1) break;
+        int idx=0; int c=getopt_long(argc,argv,\"b:dh\",opts,&idx); if(c==-1) break;
         switch(c){
-            case 'b': blockOverride=atoi(optarg); break;
-            case 'd': decrypt=true; break;
+            case \'b\': blockOverride=atoi(optarg); break;
+            case \'d\': decrypt=true; break;
             case OPT_CTR_PREVIEW: doCtrPreview=true; break;
             case OPT_GCM_DEBUG: doGcmDebug=true; break;
             case OPT_GF_MULT: doGfMult=true; break;
-            case 'h':
+            case \'h\':
             default:
-                std::cout << "Usage: "<<argv[0]<<" [--block N] [--decrypt] [--ctr-preview] [--gcm-debug] [--gf-mult]\n";
+                std::cout << \"Usage: \"<<argv[0]<<\" [--block N] [--decrypt] [--ctr-preview] [--gcm-debug] [--gf-mult]\\n\";
                 return 0;
         }
     }
+    */
+    // Manual parsing for essential flags as a temporary measure
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--decrypt") {
+            decrypt = true;
+        } else if (arg == "--ctr-preview") {
+            doCtrPreview = true;
+        } else if (arg == "--gcm-debug") {
+            doGcmDebug = true;
+        } else if (arg == "--gf-mult") {
+            doGfMult = true;
+        } else if (arg == "--help" || arg == "-h") {
+            std::cout << "Usage: " << argv[0] << " [--decrypt] [--ctr-preview] [--gcm-debug] [--gf-mult]\n";
+            std::cout << "Note: --block N is currently disabled due to getopt_long incompatibility on Windows.\n";
+            return 0;
+        }
+        // blockOverride is not parsed in this simplified version
+    }
 
-    std::filesystem::create_directories("bench");
+
+    // Ensure directory exists
+    try {
+        std::filesystem::create_directories("bench");
+    } catch (const std::filesystem::filesystem_error& e) {
+        fprintf(stderr, "Filesystem error: %s\n", e.what());
+    }
     init_T_tables();
 
     if(doCtrPreview) return ctr_preview();
     if(doGcmDebug)   return gcm_debug_run();
     if(doGfMult)     return gf_mult_bench();
+
+    // Print header for benchmark results
+    printf("%-10s %-10s %-12s %-5s %-10s %-10s %-5s\\n",
+           "TYPE", "MODE", "SIZE_BYTES", "RUN", "MS", "GiB/s", "OP");
 
     std::mt19937_64 rng(12345);
     for(const char* modeStr : MODES){
@@ -280,10 +322,114 @@ int main(int argc, char** argv) {
         std::vector<uint32_t> rk(bits==128?44:60);
         if(bits==128) expandKey128(key.data(),rk.data()); else expandKey256(key.data(),rk.data());
         init_roundKeys(rk.data(), (int)rk.size());
-        std::vector<uint8_t> iv(12); if(!isEcb) fill_random(iv.data(),12,rng);
+        std::vector<uint8_t> iv(12); if(!isEcb) fill_random(iv.data(),12,rng); // IV for CTR/GCM
 
         for(size_t sz : SIZES){
             size_t nBlocks=(sz+15)/16; size_t bytes=nBlocks*16;
+
+            printf("-------------------------------------------------------------------------------------\n");
+            printf("ROUND_TRIP_CHECK %-10s %-12zu\n", mode.c_str(), bytes); // <-- \n buraya eklendi ve : kaldırıldı
+
+            // Print Key and IV (first 8 bytes for brevity)
+            printf("  Key Used:         ");
+            for(int k_idx = 0; k_idx < std::min((size_t)8, keyBytes); ++k_idx) printf("%02x", key[k_idx]);
+            printf("...\n");
+            if(!isEcb){
+                printf("  IV Used (CTR/GCM): ");
+                for(int iv_idx = 0; iv_idx < std::min((size_t)8, iv.size()); ++iv_idx) printf("%02x", iv[iv_idx]);
+                printf("...\n");
+            }
+
+            uint8_t *h_rt_original, *h_rt_decrypted_gpu, *h_rt_cipher_gpu;
+            CHECK_CUDA(cudaMallocHost(&h_rt_original, bytes));
+            CHECK_CUDA(cudaMallocHost(&h_rt_decrypted_gpu, bytes));
+            CHECK_CUDA(cudaMallocHost(&h_rt_cipher_gpu, bytes)); // For storing GPU ciphertext
+
+            fill_random(h_rt_original, bytes, rng);
+
+            std::vector<uint8_t> h_rt_cipher(bytes); // Host buffer for ciphertext (if needed)
+
+            uint8_t *d_rt_plain, *d_rt_cipher, *d_rt_decrypted_final;
+            uint8_t *d_rt_iv = nullptr, *d_rt_tag_encrypt = nullptr, *d_rt_tag_decrypt_out = nullptr;
+
+            CHECK_CUDA(cudaMalloc(&d_rt_plain, bytes));
+            CHECK_CUDA(cudaMalloc(&d_rt_cipher, bytes));
+            CHECK_CUDA(cudaMalloc(&d_rt_decrypted_final, bytes));
+
+            CHECK_CUDA(cudaMemcpy(d_rt_plain, h_rt_original, bytes, cudaMemcpyHostToDevice));
+
+            dim3 rt_kernel_block_dim(blockOverride);
+            if (isGcm) rt_kernel_block_dim.x = THREADS_PER_BLOCK; // GCM kernels typically use fixed block size
+            dim3 rt_kernel_grid_dim((unsigned)((nBlocks + rt_kernel_block_dim.x - 1) / rt_kernel_block_dim.x));
+            if (isGcm) rt_kernel_grid_dim.x = 1; // GCM kernels typically use 1 block
+
+            if (isGcm) {
+                CHECK_CUDA(cudaMalloc(&d_rt_iv, 12));
+                CHECK_CUDA(cudaMalloc(&d_rt_tag_encrypt, 16));
+                CHECK_CUDA(cudaMalloc(&d_rt_tag_decrypt_out, 16));
+                CHECK_CUDA(cudaMemcpy(d_rt_iv, iv.data(), 12, cudaMemcpyHostToDevice));
+            }
+
+            // Perform Encryption
+            if(isEcb && bits==128) aes128_ecb_encrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_plain, d_rt_cipher, nBlocks);
+            else if(isEcb && bits==256) aes256_ecb_encrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_plain, d_rt_cipher, nBlocks);
+            else if(isCtr && bits==128){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); aes128_ctr_encrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_plain, d_rt_cipher, nBlocks,lo,hi); }
+            else if(isCtr && bits==256){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); aes256_ctr_encrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_plain, d_rt_cipher, nBlocks,lo,hi); }
+            else if(isGcm && bits==128) aes128_gcm_encrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_plain, d_rt_cipher, nBlocks, d_rt_iv, d_rt_tag_encrypt);
+            else if(isGcm && bits==256) aes256_gcm_encrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_plain, d_rt_cipher, nBlocks, d_rt_iv, d_rt_tag_encrypt);
+            CHECK_CUDA(cudaDeviceSynchronize());
+
+            // Copy ciphertext from GPU to host for printing a sample
+            CHECK_CUDA(cudaMemcpy(h_rt_cipher_gpu, d_rt_cipher, bytes, cudaMemcpyDeviceToHost));
+            printf("  Ciphertext (GPU): ");
+            for(int c_idx = 0; c_idx < std::min((size_t)16, bytes); ++c_idx) printf("%02x", h_rt_cipher_gpu[c_idx]);
+            printf("...\n");
+
+            // Perform Decryption
+            if(isEcb && bits==128) aes128_ecb_decrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_cipher, d_rt_decrypted_final, nBlocks);
+            else if(isEcb && bits==256) aes256_ecb_decrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_cipher, d_rt_decrypted_final, nBlocks);
+            else if(isCtr && bits==128){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); aes128_ctr_decrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_cipher, d_rt_decrypted_final, nBlocks,lo,hi); }
+            else if(isCtr && bits==256){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); aes256_ctr_decrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_cipher, d_rt_decrypted_final, nBlocks,lo,hi); }
+            else if(isGcm && bits==128) aes128_gcm_decrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_cipher, d_rt_decrypted_final, nBlocks, d_rt_iv, d_rt_tag_encrypt, d_rt_tag_decrypt_out);
+            else if(isGcm && bits==256) aes256_gcm_decrypt<<<rt_kernel_grid_dim,rt_kernel_block_dim>>>(d_rt_cipher, d_rt_decrypted_final, nBlocks, d_rt_iv, d_rt_tag_encrypt, d_rt_tag_decrypt_out);
+            CHECK_CUDA(cudaDeviceSynchronize());
+
+            CHECK_CUDA(cudaMemcpy(h_rt_decrypted_gpu, d_rt_decrypted_final, bytes, cudaMemcpyDeviceToHost));
+
+            bool match = true;
+            for (size_t i = 0; i < bytes; ++i) {
+                if (h_rt_original[i] != h_rt_decrypted_gpu[i]) {
+                    match = false;
+                    printf("FAIL - Mismatch at byte %zu: original %02x, decrypted %02x\\n", i, h_rt_original[i], h_rt_decrypted_gpu[i]);
+                    // Optionally print more context around mismatch
+                    // size_t start_print = (i > 5) ? (i - 5) : 0;
+                    // size_t end_print = (i + 5 < bytes) ? (i + 5) : bytes -1;
+                    // printf("Original:  "); for(size_t k=start_print; k<=end_print; ++k) printf("%02x ", h_rt_original[k]); printf("\\n");
+                    // printf("Decrypted: "); for(size_t k=start_print; k<=end_print; ++k) printf("%02x ", h_rt_decrypted_gpu[k]); printf("\\n");
+                    break;
+                }
+            }
+            if (match) {
+                // For GCM, an additional check could be to compare d_rt_tag_encrypt and d_rt_tag_decrypt_out
+                // if the decrypt kernel is expected to place the calculated tag there.
+                // However, a matching plaintext is the primary success indicator for round-trip.
+                printf("  Result:           PASS\n");
+            } else {
+                printf("  Result:           FAIL\n"); // Ensure FAIL is also followed by a newline and indented
+            }
+
+            CHECK_CUDA(cudaFreeHost(h_rt_original));
+            CHECK_CUDA(cudaFreeHost(h_rt_decrypted_gpu));
+            CHECK_CUDA(cudaFreeHost(h_rt_cipher_gpu)); // Free the new host buffer
+            CHECK_CUDA(cudaFree(d_rt_plain));
+            CHECK_CUDA(cudaFree(d_rt_cipher));
+            CHECK_CUDA(cudaFree(d_rt_decrypted_final));
+            if (d_rt_iv) CHECK_CUDA(cudaFree(d_rt_iv));
+            if (d_rt_tag_encrypt) CHECK_CUDA(cudaFree(d_rt_tag_encrypt));
+            if (d_rt_tag_decrypt_out) CHECK_CUDA(cudaFree(d_rt_tag_decrypt_out));
+            // <<< END OF ROUND-TRIP CHECK >>>
+
+            // Original benchmarking loop for NUM_RUNS
             for(int run=1; run<=NUM_RUNS; ++run){
                 uint8_t *h_in,*h_out; CHECK_CUDA(cudaMallocHost(&h_in,bytes)); CHECK_CUDA(cudaMallocHost(&h_out,bytes));
                 fill_random(h_in,bytes,rng);
@@ -292,26 +438,38 @@ int main(int argc, char** argv) {
                 if(isGcm) { CHECK_CUDA(cudaMalloc(&d_tag,16)); CHECK_CUDA(cudaMalloc(&d_iv,12)); CHECK_CUDA(cudaMemcpy(d_iv,iv.data(),12,cudaMemcpyHostToDevice)); }
                 CHECK_CUDA(cudaMemcpy(d_in,h_in,bytes,cudaMemcpyHostToDevice));
                 dim3 block(blockOverride); dim3 grid((unsigned)((nBlocks+block.x-1)/block.x));
+
+                // Create a descriptive NVTX range name for the entire benchmark iteration
+                char nvtx_benchmark_range_name[128];
+                snprintf(nvtx_benchmark_range_name, sizeof(nvtx_benchmark_range_name),
+                         "Benchmark_%s_%s_%zu_Run%d",
+                         mode.c_str(), (decrypt ? "DEC" : "ENC"), bytes, run);
+
+                NVTX_PUSH(nvtx_benchmark_range_name); // Push NVTX range for the entire iteration
+
                 cudaEvent_t s,e; cudaEventCreate(&s); cudaEventCreate(&e);
                 cudaEventRecord(s);
                 if(!decrypt){
-                    if(isEcb && bits==128){ NVTX_PUSH("ecb128_enc"); aes128_ecb_encrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
-                    else if(isEcb && bits==256){ NVTX_PUSH("ecb256_enc"); aes256_ecb_encrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
-                    else if(isCtr && bits==128){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr128_enc"); aes128_ctr_encrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
-                    else if(isCtr && bits==256){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr256_enc"); aes256_ctr_encrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
-                    else if(isGcm && bits==128){ NVTX_PUSH("gcm128_enc"); aes128_gcm_encrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag); NVTX_POP(); }
-                    else if(isGcm && bits==256){ NVTX_PUSH("gcm256_enc"); aes256_gcm_encrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag); NVTX_POP(); }
+                    if(isEcb && bits==128){ NVTX_PUSH("ecb128_enc_kernel"); aes128_ecb_encrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
+                    else if(isEcb && bits==256){ NVTX_PUSH("ecb256_enc_kernel"); aes256_ecb_encrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
+                    else if(isCtr && bits==128){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr128_enc_kernel"); aes128_ctr_encrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
+                    else if(isCtr && bits==256){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr256_enc_kernel"); aes256_ctr_encrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
+                    else if(isGcm && bits==128){ NVTX_PUSH("gcm128_enc_kernel"); aes128_gcm_encrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag); NVTX_POP(); }
+                    else if(isGcm && bits==256){ NVTX_PUSH("gcm256_enc_kernel"); aes256_gcm_encrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag); NVTX_POP(); }
                 } else {
-                    if(isEcb && bits==128){ NVTX_PUSH("ecb128_dec"); aes128_ecb_decrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
-                    else if(isEcb && bits==256){ NVTX_PUSH("ecb256_dec"); aes256_ecb_decrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
-                    else if(isCtr && bits==128){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr128_dec"); aes128_ctr_decrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
-                    else if(isCtr && bits==256){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr256_dec"); aes256_ctr_decrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
-                    else if(isGcm && bits==128){ NVTX_PUSH("gcm128_dec"); aes128_gcm_decrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag,d_tag); NVTX_POP(); }
-                    else if(isGcm && bits==256){ NVTX_PUSH("gcm256_dec"); aes256_gcm_decrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag,d_tag); NVTX_POP(); }
+                    if(isEcb && bits==128){ NVTX_PUSH("ecb128_dec_kernel"); aes128_ecb_decrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
+                    else if(isEcb && bits==256){ NVTX_PUSH("ecb256_dec_kernel"); aes256_ecb_decrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
+                    else if(isCtr && bits==128){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr128_dec_kernel"); aes128_ctr_decrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
+                    else if(isCtr && bits==256){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr256_dec_kernel"); aes256_ctr_decrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
+                    else if(isGcm && bits==128){ NVTX_PUSH("gcm128_dec_kernel"); aes128_gcm_decrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag,d_tag); NVTX_POP(); }
+                    else if(isGcm && bits==256){ NVTX_PUSH("gcm256_dec_kernel"); aes256_gcm_decrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag,d_tag); NVTX_POP(); }
                 }
-                cudaEventRecord(e); CHECK_CUDA(cudaEventSynchronize(e)); float ms=0.0f; cudaEventElapsedTime(&ms,s,e);
+                cudaEventRecord(e); CHECK_CUDA(cudaEventSynchronize(e));
+                NVTX_POP(); // Pop NVTX range for the entire iteration
+
+                float ms=0.0f; cudaEventElapsedTime(&ms,s,e);
                 double gib=(double)bytes/(double)(1ull<<30); double thr=gib/(ms/1000.0);
-                printf("RESULT_GPU,%s,%zu,%d,%.3f,%.3f,%s\n", mode.c_str(), bytes, run, ms, thr, decrypt?"DEC":"ENC");
+                printf("RESULT_GPU %-10s %-12zu %-5d %-10.3f %-10.3f %-5s\n", mode.c_str(), bytes, run, ms, thr, decrypt?"DEC":"ENC");
                 std::ofstream fg("bench/thr_gpu.csv",std::ios::app); fg<<"RESULT_GPU,"<<mode<<","<<bytes<<","<<run<<","<<ms<<","<<thr<<","<<(decrypt?"DEC":"ENC")<<"\n";
 
                 std::vector<uint8_t> host_in(bytes); CHECK_CUDA(cudaMemcpy(host_in.data(),d_in,bytes,cudaMemcpyDeviceToHost));
@@ -321,7 +479,7 @@ int main(int argc, char** argv) {
                 else if(isGcm&&bits==128) sel=&EVP_aes_128_gcm; else sel=&EVP_aes_256_gcm;
                 double cpu_thr = cpu_aes_throughput(host_in.data(), bytes, key.data(), bits, decrypt, sel);
                 double ms_cpu = (double)bytes/(cpu_thr*(1ull<<30))*1000.0;
-                printf("RESULT_CPU,%s,%zu,%d,%.3f,%.3f,%s\n", mode.c_str(), bytes, run, ms_cpu, cpu_thr, decrypt?"DEC":"ENC");
+                printf("RESULT_CPU %-10s %-12zu %-5d %-10.3f %-10.3f %-5s\n", mode.c_str(), bytes, run, ms_cpu, cpu_thr, decrypt?"DEC":"ENC");
                 std::ofstream fc("bench/thr_cpu.csv",std::ios::app); fc<<"RESULT_CPU,"<<mode<<","<<bytes<<","<<run<<","<<ms_cpu<<","<<cpu_thr<<","<<(decrypt?"DEC":"ENC")<<"\n";
 
                 CHECK_CUDA(cudaFreeHost(h_in)); CHECK_CUDA(cudaFreeHost(h_out));

--- a/main.cu
+++ b/main.cu
@@ -3,13 +3,19 @@
 #include <cstdlib>
 #include <vector>
 #include <random>
-#include <iostream>
-#include <iomanip>
-#include <algorithm>
+#include <fstream>
+#include <filesystem>
+#include <chrono>
+#include <cstring>
+#include <getopt.h>
+#include <immintrin.h>
+#include <openssl/evp.h>
 #include "aes_common.h"
 #include "profiling_helpers.h"
 
-// Error checking helper
+// -------------------------------
+// Error handling macro
+// -------------------------------
 #define CHECK_CUDA(x) do { \
     cudaError_t err = (x); \
     if (err != cudaSuccess) { \
@@ -18,388 +24,341 @@
     } \
 } while (0)
 
-// Pack 96-bit IV into ctrLo/ctrHi expected by CTR kernels
-static void packCtr(const uint8_t iv[12], uint64_t &ctrLo, uint64_t &ctrHi) {
-    uint32_t w0=0,w1=0,w2=0;
-    memcpy(&w0, iv, 4);
-    memcpy(&w1, iv+4,4);
-    memcpy(&w2, iv+8,4);
-    uint32_t w3 = 0x01000000u; // counter=1 big-endian
-    ctrLo = (uint64_t)w0 | ((uint64_t)w1<<32);
-    ctrHi = (uint64_t)w2 | ((uint64_t)w3<<32);
+// -------------------------------
+// Constants and parameters
+// -------------------------------
+constexpr int THREADS_PER_BLOCK = 256;
+constexpr int NUM_RUNS          = 5;
+static const size_t SIZES[]     = {1ull<<20, 10ull<<20, 100ull<<20, 1ull<<30};
+static const char*  MODES[]     = {"ecb-128","ecb-256","ctr-128","ctr-256","gcm-128","gcm-256"};
+
+// -------------------------------
+// CTR helper
+// -------------------------------
+static void packCtr(const uint8_t iv[12], uint64_t &lo, uint64_t &hi) {
+    uint32_t w0=0,w1=0,w2=0; memcpy(&w0,iv,4); memcpy(&w1,iv+4,4); memcpy(&w2,iv+8,4);
+    uint32_t w3=0x01000000u; lo = (uint64_t)w0 | ((uint64_t)w1<<32); hi = (uint64_t)w2 | ((uint64_t)w3<<32);
 }
 
-static void printKeySchedule(const uint32_t *keys, size_t numWords, const char *label) {
-    std::cout << label << ": ";
-    for (size_t i = 0; i < numWords; ++i) {
-        std::cout << std::hex << std::setfill('0') << std::setw(8) << keys[i] << " ";
+// -------------------------------
+// Device GF multiply used for --gf-mult and GCM debug
+// -------------------------------
+__device__ inline void gf_mul128_dev(uint64_t &Ah, uint64_t &Al, uint64_t Bh, uint64_t Bl) {
+    uint64_t Zh=0, Zl=0, Vh=Bh, Vl=Bl; const uint64_t R=0xE100000000000000ULL;
+    for(int i=0;i<128;++i){
+        if(Al & 1ULL){ Zl^=Vl; Zh^=Vh; }
+        bool carry = Vl & 1ULL;
+        Vl = (Vl>>1) | (Vh<<63); Vh >>=1; if(carry) Vh^=R;
+        Al = (Al>>1) | (Ah<<63); Ah >>=1;
     }
-    std::cout << std::dec << std::endl;
+    Ah=Zh; Al=Zl;
 }
 
-static void printInputData(const uint8_t *data, size_t len, const char *label) {
-    std::cout << label << ": ";
-    for (size_t i = 0; i < len; ++i) {
-        std::cout << std::hex << std::setfill('0') << std::setw(2) << (int)data[i] << " ";
+// Kernel performing many GF multiplies per thread
+__global__ void gf_mult_kernel(uint64_t *out) {
+    uint64_t Ah=0x0123456789abcdefULL, Al=0xfedcba9876543210ULL;
+    uint64_t Bh=0x0fedcba987654321ULL, Bl=0x1234567890abcdefULL;
+    for(int i=0;i<1000000;i++) {
+        gf_mul128_dev(Ah,Al,Bh,Bl);
+        Bh += 1; Bl += 1;
     }
-    std::cout << std::dec << std::endl;
+    out[threadIdx.x] = Ah ^ Al ^ Bh ^ Bl;
 }
 
-int main() {
-#ifdef ENABLE_NVTX
-    printf("ENABLE_NVTX is defined!\n");
-#else
-    printf("ENABLE_NVTX is NOT defined!\n");
-#endif
+// Kernel computing per-thread partial GHASH
+__global__ void gcm_partial_kernel(const uint8_t *cipher, size_t nBlocks,
+                                   uint64_t Hh, uint64_t Hl,
+                                   uint64_t *outH, uint64_t *outL) {
+    int tid = threadIdx.x;
+    size_t start = tid * nBlocks / blockDim.x;
+    size_t end   = (tid+1) * nBlocks / blockDim.x;
+    uint64_t Xh=0, Xl=0;
+    for(size_t i=start;i<end;++i){
+        uint64_t cl=((const uint64_t*)cipher)[2*i];
+        uint64_t ch=((const uint64_t*)cipher)[2*i+1];
+        Xl ^= cl; Xh ^= ch; gf_mul128_dev(Xh,Xl,Hh,Hl);
+    }
+    outH[tid]=Xh; outL[tid]=Xl;
+}
+
+// -------------------------------
+// OpenSSL throughput helper
+// -------------------------------
+static double cpu_aes_throughput(const void* src, size_t bytes,
+                                 const unsigned char* key, int bits,
+                                 bool decrypt, const EVP_CIPHER* (*cipherSel)()) {
+    std::vector<unsigned char> buf(bytes);
+    std::vector<unsigned char> iv(16,0);
+    EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+    const EVP_CIPHER *cipher = cipherSel();
+    if(decrypt) EVP_DecryptInit_ex(ctx, cipher, nullptr, key, iv.data());
+    else        EVP_EncryptInit_ex(ctx, cipher, nullptr, key, iv.data());
+    EVP_CIPHER_CTX_set_padding(ctx,0);
+    auto t0=std::chrono::high_resolution_clock::now();
+    int outLen=0,total=0;
+    if(decrypt) EVP_DecryptUpdate(ctx, buf.data(), &outLen, (const unsigned char*)src, (int)bytes);
+    else        EVP_EncryptUpdate(ctx, buf.data(), &outLen, (const unsigned char*)src, (int)bytes);
+    total += outLen;
+    if(decrypt) EVP_DecryptFinal_ex(ctx, buf.data()+total, &outLen);
+    else        EVP_EncryptFinal_ex(ctx, buf.data()+total, &outLen);
+    total += outLen;
+    auto t1=std::chrono::high_resolution_clock::now();
+    EVP_CIPHER_CTX_free(ctx);
+    double ms=std::chrono::duration<double,std::milli>(t1-t0).count();
+    double gib=(double)bytes/(double)(1ull<<30);
+    return gib/(ms/1000.0);
+}
+
+// -------------------------------
+// Helper to generate random bytes
+// -------------------------------
+static void fill_random(uint8_t *buf, size_t n, std::mt19937_64 &rng) {
+    for(size_t i=0;i<n;++i) buf[i] = static_cast<uint8_t>(rng() & 0xFF);
+}
+
+// -------------------------------
+// CTR preview routine
+// -------------------------------
+static int ctr_preview() {
+    std::mt19937_64 rng(42);
+    std::vector<uint8_t> key(16); fill_random(key.data(),16,rng);
+    std::vector<uint8_t> iv(12);  fill_random(iv.data(),12,rng);
+
+    std::vector<uint32_t> rk(44); expandKey128(key.data(), rk.data());
+    init_roundKeys(rk.data(), (int)rk.size());
+
+    uint8_t *d_in,*d_out; CHECK_CUDA(cudaMalloc(&d_in,32)); CHECK_CUDA(cudaMalloc(&d_out,32));
+    CHECK_CUDA(cudaMemset(d_in,0,32));
+    uint64_t lo=0,hi=0; packCtr(iv.data(),lo,hi);
+    NVTX_PUSH("CTR_PREVIEW");
+    aes128_ctr_encrypt<<<1,1>>>(d_in,d_out,2,lo,hi);
+    CHECK_CUDA(cudaDeviceSynchronize());
+    NVTX_POP();
+    uint8_t h_out[32]; CHECK_CUDA(cudaMemcpy(h_out,d_out,32,cudaMemcpyDeviceToHost));
+    CHECK_CUDA(cudaFree(d_in)); CHECK_CUDA(cudaFree(d_out));
+
+    printf("CTR_PREVIEW,");
+    for(int i=0;i<32;i++){ printf("%02x", h_out[i]); if(i==15) printf(","); }
+    printf("\n");
+    return 0;
+}
+
+// -------------------------------
+// GF multiply benchmark
+// -------------------------------
+static int gf_mult_bench() {
+    std::filesystem::create_directories("bench");
+    // CPU part
+    double ms_cpu=0.0; {
+        __m128i a = _mm_set_epi64x(0x0123456789abcdefULL,0xfedcba9876543210ULL);
+        __m128i b = _mm_set_epi64x(0x0fedcba987654321ULL,0x1234567890abcdefULL);
+        auto t0=std::chrono::high_resolution_clock::now();
+        for(int i=0;i<1000000;i++) {
+            __m128i r = _mm_clmulepi64_si128(a,b,0x00);
+            a = _mm_xor_si128(a,r);
+            b = _mm_xor_si128(b,r);
+        }
+        auto t1=std::chrono::high_resolution_clock::now();
+        ms_cpu=std::chrono::duration<double,std::milli>(t1-t0).count();
+    }
+    double gbps_cpu = (1000000.0*128/1e9) / (ms_cpu/1000.0);
+
+    // GPU part
+    double ms_gpu=0.0; double gbps_gpu=0.0; {
+        uint64_t *d_out; CHECK_CUDA(cudaMalloc(&d_out, THREADS_PER_BLOCK*sizeof(uint64_t)));
+        cudaEvent_t s,e; cudaEventCreate(&s); cudaEventCreate(&e);
+        cudaEventRecord(s);
+        gf_mult_kernel<<<1,THREADS_PER_BLOCK>>>(d_out);
+        cudaEventRecord(e); CHECK_CUDA(cudaEventSynchronize(e));
+        cudaEventElapsedTime(&ms_gpu,s,e); CHECK_CUDA(cudaFree(d_out));
+        gbps_gpu = (1000000.0*THREADS_PER_BLOCK*128/1e9) / (ms_gpu/1000.0);
+    }
+
+    std::ofstream f("bench/gf_mult.csv", std::ios::app);
+    f << "SRC,CPU,1000000," << ms_cpu << ',' << gbps_cpu << "\n";
+    f << "SRC,GPU," << (1000000*THREADS_PER_BLOCK) << ',' << ms_gpu << ',' << gbps_gpu << "\n";
+    std::cout << "GF_MULT CPU "<<gbps_cpu<<" Gbps\n";
+    std::cout << "GF_MULT GPU "<<gbps_gpu<<" Gbps\n";
+    return 0;
+}
+
+// -------------------------------
+// GCM debug routine: encrypt 64B and dump partial GHASH
+// -------------------------------
+static int gcm_debug_run() {
+    std::filesystem::create_directories("bench");
+    std::mt19937_64 rng(123);
+    const size_t bytes=64; size_t nBlocks=bytes/16;
+    uint8_t *h_plain,*h_cipher; CHECK_CUDA(cudaMallocHost(&h_plain,bytes)); CHECK_CUDA(cudaMallocHost(&h_cipher,bytes));
+    fill_random(h_plain,bytes,rng);
+    std::vector<uint8_t> key(16); fill_random(key.data(),16,rng);
+    std::vector<uint8_t> iv(12);  fill_random(iv.data(),12,rng);
+    std::vector<uint32_t> rk(44); expandKey128(key.data(), rk.data());
+    init_roundKeys(rk.data(), (int)rk.size());
+    uint8_t *d_plain,*d_cipher,*d_tag,*d_iv; CHECK_CUDA(cudaMalloc(&d_plain,bytes)); CHECK_CUDA(cudaMalloc(&d_cipher,bytes)); CHECK_CUDA(cudaMalloc(&d_tag,16)); CHECK_CUDA(cudaMalloc(&d_iv,12));
+    CHECK_CUDA(cudaMemcpy(d_plain,h_plain,bytes,cudaMemcpyHostToDevice));
+    CHECK_CUDA(cudaMemcpy(d_iv,iv.data(),12,cudaMemcpyHostToDevice));
+    aes128_gcm_encrypt<<<1,THREADS_PER_BLOCK>>>(d_plain,d_cipher,nBlocks,d_iv,d_tag);
+    CHECK_CUDA(cudaDeviceSynchronize());
+    CHECK_CUDA(cudaMemcpy(h_cipher,d_cipher,bytes,cudaMemcpyDeviceToHost));
+
+    // compute H = AES_k(0)
+    uint8_t *d_zero,*d_h; CHECK_CUDA(cudaMalloc(&d_zero,16)); CHECK_CUDA(cudaMalloc(&d_h,16));
+    CHECK_CUDA(cudaMemset(d_zero,0,16));
+    aes128_ecb_encrypt<<<1,1>>>(d_zero,d_h,1);
+    CHECK_CUDA(cudaDeviceSynchronize());
+    uint8_t hbuf[16]; CHECK_CUDA(cudaMemcpy(hbuf,d_h,16,cudaMemcpyDeviceToHost));
+    uint64_t Hl=((uint64_t*)hbuf)[0]; uint64_t Hh=((uint64_t*)hbuf)[1];
+    CHECK_CUDA(cudaFree(d_zero)); CHECK_CUDA(cudaFree(d_h));
+
+    // partial GHASH
+    uint64_t *d_ph,*d_pl; CHECK_CUDA(cudaMalloc(&d_ph,THREADS_PER_BLOCK*sizeof(uint64_t))); CHECK_CUDA(cudaMalloc(&d_pl,THREADS_PER_BLOCK*sizeof(uint64_t)));
+    gcm_partial_kernel<<<1,THREADS_PER_BLOCK>>>(d_cipher,nBlocks,Hh,Hl,d_ph,d_pl);
+    CHECK_CUDA(cudaDeviceSynchronize());
+    std::vector<uint64_t> ph(THREADS_PER_BLOCK), pl(THREADS_PER_BLOCK);
+    CHECK_CUDA(cudaMemcpy(ph.data(),d_ph,THREADS_PER_BLOCK*sizeof(uint64_t),cudaMemcpyDeviceToHost));
+    CHECK_CUDA(cudaMemcpy(pl.data(),d_pl,THREADS_PER_BLOCK*sizeof(uint64_t),cudaMemcpyDeviceToHost));
+    CHECK_CUDA(cudaFree(d_ph)); CHECK_CUDA(cudaFree(d_pl));
+    std::ofstream out("bench/ghash_partials.txt");
+    for(int i=0;i<THREADS_PER_BLOCK;i++)
+        out << i << "," << std::hex << ph[i] << "," << pl[i] << std::dec << "\n";
+
+    CHECK_CUDA(cudaFree(d_plain)); CHECK_CUDA(cudaFree(d_cipher)); CHECK_CUDA(cudaFree(d_tag)); CHECK_CUDA(cudaFree(d_iv));
+    CHECK_CUDA(cudaFreeHost(h_plain)); CHECK_CUDA(cudaFreeHost(h_cipher));
+    std::cout << "GHASH partials written to bench/ghash_partials.txt\n";
+    return 0;
+}
+
+// -------------------------------
+// Main benchmark loop
+// -------------------------------
+int main(int argc, char** argv) {
+    int blockOverride = THREADS_PER_BLOCK;
+    bool decrypt=false, doCtrPreview=false, doGcmDebug=false, doGfMult=false;
+
+    enum { OPT_CTR_PREVIEW=1000, OPT_GCM_DEBUG, OPT_GF_MULT };
+    static struct option opts[] = {
+        {"block", required_argument, nullptr, 'b'},
+        {"decrypt", no_argument, nullptr, 'd'},
+        {"ctr-preview", no_argument, nullptr, OPT_CTR_PREVIEW},
+        {"gcm-debug", no_argument, nullptr, OPT_GCM_DEBUG},
+        {"gf-mult", no_argument, nullptr, OPT_GF_MULT},
+        {"help", no_argument, nullptr, 'h'},
+        {0,0,0,0}
+    };
+    while(true){
+        int idx=0; int c=getopt_long(argc,argv,"b:dh",opts,&idx); if(c==-1) break;
+        switch(c){
+            case 'b': blockOverride=atoi(optarg); break;
+            case 'd': decrypt=true; break;
+            case OPT_CTR_PREVIEW: doCtrPreview=true; break;
+            case OPT_GCM_DEBUG: doGcmDebug=true; break;
+            case OPT_GF_MULT: doGfMult=true; break;
+            case 'h':
+            default:
+                std::cout << "Usage: "<<argv[0]<<" [--block N] [--decrypt] [--ctr-preview] [--gcm-debug] [--gf-mult]\n";
+                return 0;
+        }
+    }
+
+    std::filesystem::create_directories("bench");
     init_T_tables();
-    std::vector<size_t> testSizes = {10 << 20};
-    std::vector<std::string> modes = {"ecb", "ctr", "gcm"};
-    std::vector<int> keyBitsOptions = {128, 256};
 
-    std::mt19937_64 rng(12345ULL);
-    for (const std::string &mode : modes) {
-        for (int keyBits : keyBitsOptions) {
-            size_t keyBytes = keyBits / 8;
-            std::vector<uint8_t> key(keyBytes);
-            for (auto &b : key) b = uint8_t(rng() & 0xFF);
-            std::vector<uint8_t> iv(16, 0);
-            if (mode != "ecb")
-                for (size_t i=0;i<12;++i) iv[i] = uint8_t(rng() & 0xFF);
+    if(doCtrPreview) return ctr_preview();
+    if(doGcmDebug)   return gcm_debug_run();
+    if(doGfMult)     return gf_mult_bench();
 
-            std::vector<uint32_t> roundKeys(keyBits==128?44:60);
-            if (keyBits==128) expandKey128(key.data(), roundKeys.data());
-            else expandKey256(key.data(), roundKeys.data());
-            printKeySchedule(roundKeys.data(), roundKeys.size(), "Host Key Schedule");
-            init_roundKeys(roundKeys.data(), (int)roundKeys.size());
-            std::vector<uint32_t> deviceKeys(roundKeys.size());
-            CHECK_CUDA(cudaMemcpyFromSymbol(deviceKeys.data(), d_roundKeys, roundKeys.size()*sizeof(uint32_t)));
-            printKeySchedule(deviceKeys.data(), deviceKeys.size(), "Device Key Schedule");
+    std::mt19937_64 rng(12345);
+    for(const char* modeStr : MODES){
+        std::string mode(modeStr);
+        bool isEcb = mode.find("ecb")==0;
+        bool isCtr = mode.find("ctr")==0;
+        bool isGcm = mode.find("gcm")==0;
+        int bits = mode.find("256")!=std::string::npos ? 256 : 128;
+        size_t keyBytes = bits/8;
+        std::vector<uint8_t> key(keyBytes); fill_random(key.data(),keyBytes,rng);
+        std::vector<uint32_t> rk(bits==128?44:60);
+        if(bits==128) expandKey128(key.data(),rk.data()); else expandKey256(key.data(),rk.data());
+        init_roundKeys(rk.data(), (int)rk.size());
+        std::vector<uint8_t> iv(12); if(!isEcb) fill_random(iv.data(),12,rng);
 
-            for (size_t dataBytes : testSizes) {
-                size_t nBlocks = (dataBytes + 15) / 16;
-                dataBytes = nBlocks * 16;
-                std::vector<uint8_t> h_plain(dataBytes);
-                for (auto &b : h_plain) b = uint8_t(rng() & 0xFF);
-                std::vector<uint8_t> h_cipher(dataBytes);
-                std::vector<uint8_t> h_recovered(dataBytes);
-                uint8_t tagCPU[16], tagGPU[16];
-
-                uint8_t *d_plain=nullptr,*d_cipher=nullptr,*d_tag=nullptr;
-                // NVTX Start: Malloc
-                NVTX_PUSH("Malloc");
-                CHECK_CUDA(cudaMalloc(&d_plain, dataBytes));
-                NVTX_POP();
-                // NVTX End: Malloc
-                // NVTX Start: Malloc
-                NVTX_PUSH("Malloc");
-                CHECK_CUDA(cudaMalloc(&d_cipher, dataBytes));
-                NVTX_POP();
-                // NVTX End: Malloc
-                if (mode=="gcm") {
-                    // NVTX Start: Malloc
-                    NVTX_PUSH("Malloc");
-                    CHECK_CUDA(cudaMalloc(&d_tag,16));
-                    NVTX_POP();
-                    // NVTX End: Malloc
+        for(size_t sz : SIZES){
+            size_t nBlocks=(sz+15)/16; size_t bytes=nBlocks*16;
+            for(int run=1; run<=NUM_RUNS; ++run){
+                uint8_t *h_in,*h_out; CHECK_CUDA(cudaMallocHost(&h_in,bytes)); CHECK_CUDA(cudaMallocHost(&h_out,bytes));
+                fill_random(h_in,bytes,rng);
+                uint8_t *d_in,*d_out,*d_tag=nullptr,*d_iv=nullptr;
+                CHECK_CUDA(cudaMalloc(&d_in,bytes)); CHECK_CUDA(cudaMalloc(&d_out,bytes));
+                if(isGcm) { CHECK_CUDA(cudaMalloc(&d_tag,16)); CHECK_CUDA(cudaMalloc(&d_iv,12)); CHECK_CUDA(cudaMemcpy(d_iv,iv.data(),12,cudaMemcpyHostToDevice)); }
+                CHECK_CUDA(cudaMemcpy(d_in,h_in,bytes,cudaMemcpyHostToDevice));
+                dim3 block(blockOverride); dim3 grid((unsigned)((nBlocks+block.x-1)/block.x));
+                cudaEvent_t s,e; cudaEventCreate(&s); cudaEventCreate(&e);
+                cudaEventRecord(s);
+                if(!decrypt){
+                    if(isEcb && bits==128){ NVTX_PUSH("ecb128_enc"); aes128_ecb_encrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
+                    else if(isEcb && bits==256){ NVTX_PUSH("ecb256_enc"); aes256_ecb_encrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
+                    else if(isCtr && bits==128){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr128_enc"); aes128_ctr_encrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
+                    else if(isCtr && bits==256){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr256_enc"); aes256_ctr_encrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
+                    else if(isGcm && bits==128){ NVTX_PUSH("gcm128_enc"); aes128_gcm_encrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag); NVTX_POP(); }
+                    else if(isGcm && bits==256){ NVTX_PUSH("gcm256_enc"); aes256_gcm_encrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag); NVTX_POP(); }
+                } else {
+                    if(isEcb && bits==128){ NVTX_PUSH("ecb128_dec"); aes128_ecb_decrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
+                    else if(isEcb && bits==256){ NVTX_PUSH("ecb256_dec"); aes256_ecb_decrypt<<<grid,block>>>(d_in,d_out,nBlocks); NVTX_POP(); }
+                    else if(isCtr && bits==128){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr128_dec"); aes128_ctr_decrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
+                    else if(isCtr && bits==256){ uint64_t lo,hi; packCtr(iv.data(),lo,hi); NVTX_PUSH("ctr256_dec"); aes256_ctr_decrypt<<<grid,block>>>(d_in,d_out,nBlocks,lo,hi); NVTX_POP(); }
+                    else if(isGcm && bits==128){ NVTX_PUSH("gcm128_dec"); aes128_gcm_decrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag,d_tag); NVTX_POP(); }
+                    else if(isGcm && bits==256){ NVTX_PUSH("gcm256_dec"); aes256_gcm_decrypt<<<1,THREADS_PER_BLOCK>>>(d_in,d_out,nBlocks,d_iv,d_tag,d_tag); NVTX_POP(); }
                 }
-                printInputData(h_plain.data(), std::min<size_t>(64, h_plain.size()), "Host Input Data");
-                // NVTX Start: Memcpy Host→Device
-                NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                CHECK_CUDA(cudaMemcpy(d_plain, h_plain.data(), dataBytes, cudaMemcpyHostToDevice));
-                NVTX_POP();
-                // NVTX End: Memcpy Host→Device
-                std::vector<uint8_t> deviceInput(h_plain.size());
-                // NVTX Start: Memcpy Device→Host
-                NVTX_PUSH("Memcpy Device\xE2\x86\x92Host");
-                CHECK_CUDA(cudaMemcpy(deviceInput.data(), d_plain, dataBytes, cudaMemcpyDeviceToHost));
-                NVTX_POP();
-                // NVTX End: Memcpy Device→Host
-                printInputData(deviceInput.data(), std::min<size_t>(64, deviceInput.size()), "Device Input Data");
+                cudaEventRecord(e); CHECK_CUDA(cudaEventSynchronize(e)); float ms=0.0f; cudaEventElapsedTime(&ms,s,e);
+                double gib=(double)bytes/(double)(1ull<<30); double thr=gib/(ms/1000.0);
+                printf("RESULT_GPU,%s,%zu,%d,%.3f,%.3f,%s\n", mode.c_str(), bytes, run, ms, thr, decrypt?"DEC":"ENC");
+                std::ofstream fg("bench/thr_gpu.csv",std::ios::app); fg<<"RESULT_GPU,"<<mode<<","<<bytes<<","<<run<<","<<ms<<","<<thr<<","<<(decrypt?"DEC":"ENC")<<"\n";
 
-                dim3 block(256);
-                dim3 grid((unsigned)((nBlocks + block.x - 1)/block.x));
-                cudaEvent_t start,stop; cudaEventCreate(&start); cudaEventCreate(&stop);
-                cudaEventRecord(start);
-                if (mode=="ecb" && keyBits==128) {
-                    // NVTX Start: ECB-128 Encrypt
-                    NVTX_PUSH("ECB-128 Encrypt");
-                    aes128_ecb_encrypt<<<grid,block>>>(d_plain,d_cipher,nBlocks);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: ECB-128 Encrypt
-                } else if (mode=="ecb" && keyBits==256) {
-                    // NVTX Start: ECB-256 Encrypt
-                    NVTX_PUSH("ECB-256 Encrypt");
-                    aes256_ecb_encrypt<<<grid,block>>>(d_plain,d_cipher,nBlocks);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: ECB-256 Encrypt
-                } else if (mode=="ctr" && keyBits==128) {
-                    uint64_t ctrLo=0, ctrHi=0; packCtr(iv.data(),ctrLo,ctrHi);
-                    // NVTX Start: CTR-128 Encrypt
-                    NVTX_PUSH("CTR-128 Encrypt");
-                    aes128_ctr_encrypt<<<grid,block>>>(d_plain,d_cipher,nBlocks,ctrLo,ctrHi);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: CTR-128 Encrypt
-                } else if (mode=="ctr" && keyBits==256) {
-                    uint64_t ctrLo=0, ctrHi=0; packCtr(iv.data(),ctrLo,ctrHi);
-                    // NVTX Start: CTR-256 Encrypt
-                    NVTX_PUSH("CTR-256 Encrypt");
-                    aes256_ctr_encrypt<<<grid,block>>>(d_plain,d_cipher,nBlocks,ctrLo,ctrHi);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: CTR-256 Encrypt
-                } else if (mode=="gcm" && keyBits==128) {
-                    uint8_t *d_iv=nullptr; 
-                    // NVTX Start: Malloc
-                    NVTX_PUSH("Malloc");
-                    CHECK_CUDA(cudaMalloc(&d_iv,12));
-                    NVTX_POP();
-                    // NVTX End: Malloc
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_iv, iv.data(),12,cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    // NVTX Start: GCM-128 Encrypt
-                    NVTX_PUSH("GCM-128 Encrypt");
-                    aes128_gcm_encrypt<<<1,256>>>(d_plain,d_cipher,nBlocks,d_iv,d_tag);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: GCM-128 Encrypt
-                    // NVTX Start: Free
-                    NVTX_PUSH("Free");
-                    CHECK_CUDA(cudaFree(d_iv));
-                    NVTX_POP();
-                    // NVTX End: Free
-                } else if (mode=="gcm" && keyBits==256) {
-                    uint8_t *d_iv=nullptr; 
-                    // NVTX Start: Malloc
-                    NVTX_PUSH("Malloc");
-                    CHECK_CUDA(cudaMalloc(&d_iv,12));
-                    NVTX_POP();
-                    // NVTX End: Malloc
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_iv, iv.data(),12,cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    // NVTX Start: GCM-256 Encrypt
-                    NVTX_PUSH("GCM-256 Encrypt");
-                    aes256_gcm_encrypt<<<1,256>>>(d_plain,d_cipher,nBlocks,d_iv,d_tag);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: GCM-256 Encrypt
-                    // NVTX Start: Free
-                    NVTX_PUSH("Free");
-                    CHECK_CUDA(cudaFree(d_iv));
-                    NVTX_POP();
-                    // NVTX End: Free
-                }
-                cudaEventRecord(stop);
-                CHECK_CUDA(cudaGetLastError());
-                CHECK_CUDA(cudaEventSynchronize(stop));
-                float ms=0.0f; cudaEventElapsedTime(&ms,start,stop);
-                double gb = (double)dataBytes/(1<<30); double thr = gb/(ms/1000.0);
-                std::cout << "[GPU] " << mode << "-" << keyBits << " processed "
-                          << (double)dataBytes/(1<<20) << " MiB in " << ms
-                          << " ms -> " << thr << " GiB/s" << std::endl;
+                std::vector<uint8_t> host_in(bytes); CHECK_CUDA(cudaMemcpy(host_in.data(),d_in,bytes,cudaMemcpyDeviceToHost));
+                const EVP_CIPHER* (*sel)();
+                if(isEcb&&bits==128) sel=&EVP_aes_128_ecb; else if(isEcb&&bits==256) sel=&EVP_aes_256_ecb;
+                else if(isCtr&&bits==128) sel=&EVP_aes_128_ctr; else if(isCtr&&bits==256) sel=&EVP_aes_256_ctr;
+                else if(isGcm&&bits==128) sel=&EVP_aes_128_gcm; else sel=&EVP_aes_256_gcm;
+                double cpu_thr = cpu_aes_throughput(host_in.data(), bytes, key.data(), bits, decrypt, sel);
+                double ms_cpu = (double)bytes/(cpu_thr*(1ull<<30))*1000.0;
+                printf("RESULT_CPU,%s,%zu,%d,%.3f,%.3f,%s\n", mode.c_str(), bytes, run, ms_cpu, cpu_thr, decrypt?"DEC":"ENC");
+                std::ofstream fc("bench/thr_cpu.csv",std::ios::app); fc<<"RESULT_CPU,"<<mode<<","<<bytes<<","<<run<<","<<ms_cpu<<","<<cpu_thr<<","<<(decrypt?"DEC":"ENC")<<"\n";
 
-                // NVTX Start: Memcpy Device→Host
-                NVTX_PUSH("Memcpy Device\xE2\x86\x92Host");
-                CHECK_CUDA(cudaMemcpy(h_cipher.data(), d_cipher, dataBytes, cudaMemcpyDeviceToHost));
-                NVTX_POP();
-                // NVTX End: Memcpy Device→Host
-                if (mode=="gcm") {
-                    // NVTX Start: Memcpy Device→Host
-                    NVTX_PUSH("Memcpy Device\xE2\x86\x92Host");
-                    CHECK_CUDA(cudaMemcpy(tagGPU, d_tag, 16, cudaMemcpyDeviceToHost));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Device→Host
-                }
-
-                if (mode=="ecb" && keyBits==128) {
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    // NVTX Start: ECB-128 Decrypt
-                    NVTX_PUSH("ECB-128 Decrypt");
-                    aes128_ecb_decrypt<<<grid,block>>>(d_cipher,d_plain,nBlocks);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: ECB-128 Decrypt
-                } else if (mode=="ecb" && keyBits==256) {
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    // NVTX Start: ECB-256 Decrypt
-                    NVTX_PUSH("ECB-256 Decrypt");
-                    aes256_ecb_decrypt<<<grid,block>>>(d_cipher,d_plain,nBlocks);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: ECB-256 Decrypt
-                } else if (mode=="ctr" && keyBits==128) {
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    uint64_t ctrLo=0, ctrHi=0; packCtr(iv.data(),ctrLo,ctrHi);
-                    // NVTX Start: CTR-128 Decrypt
-                    NVTX_PUSH("CTR-128 Decrypt");
-                    aes128_ctr_decrypt<<<grid,block>>>(d_cipher,d_plain,nBlocks,ctrLo,ctrHi);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: CTR-128 Decrypt
-                } else if (mode=="ctr" && keyBits==256) {
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    uint64_t ctrLo=0, ctrHi=0; packCtr(iv.data(),ctrLo,ctrHi);
-                    // NVTX Start: CTR-256 Decrypt
-                    NVTX_PUSH("CTR-256 Decrypt");
-                    aes256_ctr_decrypt<<<grid,block>>>(d_cipher,d_plain,nBlocks,ctrLo,ctrHi);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: CTR-256 Decrypt
-                } else if (mode=="gcm" && keyBits==128) {
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    uint8_t *d_iv2=nullptr; 
-                    // NVTX Start: Malloc
-                    NVTX_PUSH("Malloc");
-                    CHECK_CUDA(cudaMalloc(&d_iv2,12));
-                    NVTX_POP();
-                    // NVTX End: Malloc
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_iv2, iv.data(),12,cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    // NVTX Start: GCM-128 Decrypt
-                    NVTX_PUSH("GCM-128 Decrypt");
-                    aes128_gcm_decrypt<<<1,256>>>(d_cipher,d_plain,nBlocks,d_iv2,d_tag,d_tag);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: GCM-128 Decrypt
-                    // NVTX Start: Free
-                    NVTX_PUSH("Free");
-                    CHECK_CUDA(cudaFree(d_iv2));
-                    NVTX_POP();
-                    // NVTX End: Free
-                } else if (mode=="gcm" && keyBits==256) {
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_cipher, h_cipher.data(), dataBytes, cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    uint8_t *d_iv2=nullptr; 
-                    // NVTX Start: Malloc
-                    NVTX_PUSH("Malloc");
-                    CHECK_CUDA(cudaMalloc(&d_iv2,12));
-                    NVTX_POP();
-                    // NVTX End: Malloc
-                    // NVTX Start: Memcpy Host→Device
-                    NVTX_PUSH("Memcpy Host\xE2\x86\x92Device");
-                    CHECK_CUDA(cudaMemcpy(d_iv2, iv.data(),12,cudaMemcpyHostToDevice));
-                    NVTX_POP();
-                    // NVTX End: Memcpy Host→Device
-                    // NVTX Start: GCM-256 Decrypt
-                    NVTX_PUSH("GCM-256 Decrypt");
-                    aes256_gcm_decrypt<<<1,256>>>(d_cipher,d_plain,nBlocks,d_iv2,d_tag,d_tag);
-                    CHECK_CUDA(cudaGetLastError());
-                    CHECK_CUDA(cudaDeviceSynchronize());
-                    NVTX_POP();
-                    // NVTX End: GCM-256 Decrypt
-                    // NVTX Start: Free
-                    NVTX_PUSH("Free");
-                    CHECK_CUDA(cudaFree(d_iv2));
-                    NVTX_POP();
-                    // NVTX End: Free
-                }
-                CHECK_CUDA(cudaDeviceSynchronize());
-                // NVTX Start: Memcpy Device→Host
-                NVTX_PUSH("Memcpy Device\xE2\x86\x92Host");
-                CHECK_CUDA(cudaMemcpy(h_recovered.data(), d_plain, dataBytes, cudaMemcpyDeviceToHost));
-                NVTX_POP();
-                // NVTX End: Memcpy Device→Host
-                bool match = (h_recovered == h_plain);
-                std::cout << "    Round-trip " << mode << "-" << keyBits << " "
-                          << (double)dataBytes/(1<<20) << " MiB "
-                          << (match?"PASS":"FAIL") << std::endl;
-                if(!match) {
-                    for(size_t i=0;i<std::min<size_t>(64,dataBytes);++i) {
-                        if(h_recovered[i]!=h_plain[i]) {
-                            printf("Mismatch at byte %zu: got %02x, exp %02x\n", i, h_recovered[i], h_plain[i]);
-                            break;
-                        }
-                    }
-                }
-#ifdef ENABLE_OPENSSL_VALIDATION
-                {
-                    const EVP_CIPHER *cipher_algo=nullptr;
-                    if (mode=="ecb" && keyBits==128) cipher_algo = EVP_aes_128_ecb();
-                    else if (mode=="ecb" && keyBits==256) cipher_algo = EVP_aes_256_ecb();
-                    else if (mode=="ctr" && keyBits==128) cipher_algo = EVP_aes_128_ctr();
-                    else if (mode=="ctr" && keyBits==256) cipher_algo = EVP_aes_256_ctr();
-                    else if (mode=="gcm" && keyBits==128) cipher_algo = EVP_aes_128_gcm();
-                    else if (mode=="gcm" && keyBits==256) cipher_algo = EVP_aes_256_gcm();
-                    if (!cipher_algo) {
-                        std::cerr << "[CPU] OpenSSL cipher not available for " << mode << "-" << keyBits << "\n";
-                    } else {
-                        std::vector<uint8_t> cpu_out(dataBytes);
-                        EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
-                        EVP_EncryptInit_ex(ctx, cipher_algo, nullptr, nullptr, nullptr);
-                        EVP_CIPHER_CTX_set_padding(ctx,0);
-                        EVP_EncryptInit_ex(ctx,nullptr,nullptr,key.data(),(mode=="ecb"?nullptr:iv.data()));
-                        int outLen=0,totalLen=0;
-                        EVP_EncryptUpdate(ctx,cpu_out.data(),&outLen,h_plain.data(),(int)dataBytes);
-                        totalLen += outLen;
-                        EVP_EncryptFinal_ex(ctx,cpu_out.data()+totalLen,&outLen);
-                        totalLen += outLen;
-                        if (mode=="gcm") {
-                            EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, tagCPU);
-                        }
-                        EVP_CIPHER_CTX_free(ctx);
-                        bool ok=true;
-                        if (mode=="gcm") {
-                            ok = (cpu_out==h_cipher) && (std::memcmp(tagCPU,tagGPU,16)==0);
-                        } else {
-                            ok = (cpu_out==h_cipher);
-                        }
-                        std::cout << "    OpenSSL CPU match: " << (ok?"[✓]":"[✗]") << std::endl;
-                    }
-                }
-#endif
-                if(d_tag) cudaMemset(d_tag,0,16);
-                // NVTX Start: Free
-                NVTX_PUSH("Free");
-                cudaFree(d_plain); cudaFree(d_cipher); if(d_tag) cudaFree(d_tag);
-                NVTX_POP();
-                // NVTX End: Free
+                CHECK_CUDA(cudaFreeHost(h_in)); CHECK_CUDA(cudaFreeHost(h_out));
+                CHECK_CUDA(cudaFree(d_in)); CHECK_CUDA(cudaFree(d_out)); if(d_tag) CHECK_CUDA(cudaFree(d_tag)); if(d_iv) CHECK_CUDA(cudaFree(d_iv));
             }
         }
     }
     return 0;
 }
+
+/*
+BUILD:
+cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release -j
+
+BASELINE RUN (all figures R-1..R-3):
+build/CudaProject.exe
+
+OCCUPANCY SWEEP (M-2, D-3):
+for %B in (32 64 128 256 512) do build\CudaProject.exe --block %B
+
+CTR COUNTER (I-4):
+build/CudaProject.exe --ctr-preview
+
+GHASH PARTIALS (M-3):
+build/CudaProject.exe --gcm-debug
+
+GF MULTIPLY (D-2):
+build/CudaProject.exe --gf-mult
+
+NSYS TIMELINE + MEM-TRACE (M-1 & M-4):
+nsys profile --trace cuda,nvtx -o bench/run build/CudaProject.exe
+
+ROOFLINE METRICS (M-5, D-1):
+ncu --metrics flop_count_sp,dram__bytes_read.sum,dram__bytes_write.sum
+--set full --csv --target-processes all build/CudaProject.exe
+
+PTX DUMPS (D-5):
+nvdisasm --print-code aes128_ecb.cu.obj > bench/ptx_lookup.txt
+*/


### PR DESCRIPTION
## Summary
- overhaul `main.cu` to support command line flags and benchmarking loops
- add GF-multiply benchmark and GHASH debug helpers
- emit throughput logs for GPU and CPU, handling decrypt mode
- document build and profiling steps directly in the source file

## Testing
- ❌ `cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release` (failed to find nvcc)


------
https://chatgpt.com/codex/tasks/task_e_684df25674ec83249db5e0c3ff3fbb4d